### PR TITLE
[GUI] Load and save ini settings from memory

### DIFF
--- a/libs/flexgui/src/Application.cpp
+++ b/libs/flexgui/src/Application.cpp
@@ -14,6 +14,8 @@
 #include <glm/glm.hpp>
 
 #include <iostream>
+#include <fstream>
+#include "ini.embed"
 
 extern bool g_ApplicationRunning;
 static FlexGUI::Application* s_Instance = nullptr;
@@ -100,12 +102,15 @@ namespace FlexGUI {
 		ImPlot::CreateContext();
 
 		ImGuiIO& io = ImGui::GetIO(); (void)io;
+
 		io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
 		//io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 		io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
 		io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
+		io.IniFilename = NULL;
 		//io.ConfigViewportsNoAutoMerge = true;
 		//io.ConfigViewportsNoTaskBarIcon = true;
+		ImGui::LoadIniSettingsFromMemory(g_ImGuiIniSettings, g_ImGuiIniSettingsSize);
 
 		// Setup Dear ImGui style
 		ImGui::StyleColorsDark();
@@ -133,10 +138,18 @@ namespace FlexGUI {
 
 	void Application::Shutdown()
 	{
+		size_t ini_size;
+		const char* ini_settings = ImGui::SaveIniSettingsToMemory(&ini_size);
+		std::ofstream ini_file("ini.embed");
+		ini_file << "const char* g_ImGuiIniSettings = R\"(" << std::string(ini_settings, ini_size) << ")\";\n";
+		ini_file << "size_t g_ImGuiIniSettingsSize = " << ini_size << ";";
+		ini_file.close();
+
 		for (auto& layer : m_LayerStack)
 			layer->OnDetach();
 
 		m_LayerStack.clear();
+
 
 		ImGui_ImplOpenGL3_Shutdown();
 		ImGui_ImplGlfw_Shutdown();

--- a/libs/flexgui/src/ini.embed
+++ b/libs/flexgui/src/ini.embed
@@ -1,0 +1,29 @@
+const char* g_ImGuiIniSettings = R"([Window][DockSpace Demo]
+Pos=0,0
+Size=1600,900
+Collapsed=0
+
+[Window][Debug##Default]
+Pos=60,60
+Size=400,400
+Collapsed=0
+
+[Window][Buttons]
+Pos=0,19
+Size=514,881
+Collapsed=0
+DockId=0x00000001,0
+
+[Window][Graphs]
+Pos=516,19
+Size=1084,881
+Collapsed=0
+DockId=0x00000002,0
+
+[Docking][Data]
+DockSpace   ID=0xF2944C7F Window=0x4647B76E Pos=95,128 Size=1600,881 Split=X
+  DockNode  ID=0x00000001 Parent=0xF2944C7F SizeRef=514,756 CentralNode=1 Selected=0x296642D0
+  DockNode  ID=0x00000002 Parent=0xF2944C7F SizeRef=1084,756 Selected=0x43C7209E
+
+)";
+size_t g_ImGuiIniSettingsSize = 538;


### PR DESCRIPTION
Executable now outputs an embedable file when the gui window is closed. This embedable file can be included at compile time to set default positions for each window & dockspaces. 